### PR TITLE
Add shorthands for packing timestamps

### DIFF
--- a/include/msgpack/object.h
+++ b/include/msgpack/object.h
@@ -39,7 +39,8 @@ typedef enum {
     MSGPACK_OBJECT_ARRAY                = 0x06,
     MSGPACK_OBJECT_MAP                  = 0x07,
     MSGPACK_OBJECT_BIN                  = 0x08,
-    MSGPACK_OBJECT_EXT                  = 0x09
+    MSGPACK_OBJECT_EXT                  = 0x09,
+    MSGPACK_OBJECT_TIMESTAMP            = 0x0B
 } msgpack_object_type;
 
 
@@ -72,6 +73,11 @@ typedef struct {
     const char* ptr;
 } msgpack_object_ext;
 
+typedef struct {
+    int8_t type;
+    struct timespec timespec;
+} msgpack_object_timestamp;
+
 typedef union {
     bool boolean;
     uint64_t u64;
@@ -85,6 +91,7 @@ typedef union {
     msgpack_object_str str;
     msgpack_object_bin bin;
     msgpack_object_ext ext;
+    msgpack_object_timestamp time;
 } msgpack_object_union;
 
 typedef struct msgpack_object {

--- a/include/msgpack/object.h
+++ b/include/msgpack/object.h
@@ -12,6 +12,7 @@
 
 #include "zone.h"
 #include <stdio.h>
+#include <time.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,8 +40,10 @@ typedef enum {
     MSGPACK_OBJECT_ARRAY                = 0x06,
     MSGPACK_OBJECT_MAP                  = 0x07,
     MSGPACK_OBJECT_BIN                  = 0x08,
-    MSGPACK_OBJECT_EXT                  = 0x09,
-    MSGPACK_OBJECT_TIMESTAMP            = 0x0B
+#ifdef TIME_UTC
+    MSGPACK_OBJECT_TIMESTAMP            = 0x0B,
+#endif
+    MSGPACK_OBJECT_EXT                  = 0x09
 } msgpack_object_type;
 
 

--- a/include/msgpack/pack.h
+++ b/include/msgpack/pack.h
@@ -98,6 +98,9 @@ static int msgpack_pack_bin_body(msgpack_packer* pk, const void* b, size_t l);
 static int msgpack_pack_ext(msgpack_packer* pk, size_t l, int8_t type);
 static int msgpack_pack_ext_body(msgpack_packer* pk, const void* b, size_t l);
 
+static int msgpack_pack_timestamp(msgpack_packer* pk, struct timespec time);
+static int msgpack_pack_timestamp_now(msgpack_packer* pk);
+
 MSGPACK_DLLEXPORT
 int msgpack_pack_object(msgpack_packer* pk, msgpack_object d);
 

--- a/include/msgpack/pack.h
+++ b/include/msgpack/pack.h
@@ -98,8 +98,10 @@ static int msgpack_pack_bin_body(msgpack_packer* pk, const void* b, size_t l);
 static int msgpack_pack_ext(msgpack_packer* pk, size_t l, int8_t type);
 static int msgpack_pack_ext_body(msgpack_packer* pk, const void* b, size_t l);
 
+#ifdef TIME_UTC
 static int msgpack_pack_timestamp(msgpack_packer* pk, struct timespec time);
 static int msgpack_pack_timestamp_now(msgpack_packer* pk);
+#endif
 
 MSGPACK_DLLEXPORT
 int msgpack_pack_object(msgpack_packer* pk, msgpack_object d);

--- a/include/msgpack/pack_define.h
+++ b/include/msgpack/pack_define.h
@@ -13,6 +13,7 @@
 #include "msgpack/sysdep.h"
 #include <limits.h>
 #include <string.h>
+#include <time.h>
 
 #endif /* msgpack/pack_define.h */
 

--- a/include/msgpack/pack_define.h
+++ b/include/msgpack/pack_define.h
@@ -13,7 +13,6 @@
 #include "msgpack/sysdep.h"
 #include <limits.h>
 #include <string.h>
-#include <time.h>
 
 #endif /* msgpack/pack_define.h */
 

--- a/include/msgpack/pack_template.h
+++ b/include/msgpack/pack_template.h
@@ -896,8 +896,8 @@ msgpack_pack_inline_func(_ext_body)(msgpack_pack_user x, const void* b, size_t l
 
 msgpack_pack_inline_func(_timestamp)(msgpack_pack_user x, struct timespec time)
 {
-    if ((time.tv_sec >> 34) == 0) {
-        uint64_t data64 = (time.tv_nsec << 34) | time.tv_sec;
+    if (sizeof(time.tv_sec) < 34 || (time.tv_sec >> 34) == 0) {
+        uint64_t data64 = ((uint64_t) time.tv_nsec << 34) | time.tv_sec;
         if (data64 & 0xffffffff00000000L)   {
             // timestamp 64
             msgpack_pack_ext(x, 8, -1);

--- a/include/msgpack/pack_template.h
+++ b/include/msgpack/pack_template.h
@@ -894,6 +894,8 @@ msgpack_pack_inline_func(_ext_body)(msgpack_pack_user x, const void* b, size_t l
  * Timestamp
  */
 
+#ifdef TIME_UTC
+
 msgpack_pack_inline_func(_timestamp)(msgpack_pack_user x, struct timespec time)
 {
     if (sizeof(time.tv_sec) < 34 || (time.tv_sec >> 34) == 0) {
@@ -925,6 +927,8 @@ msgpack_pack_inline_func(_timestamp_now)(msgpack_pack_user x)
     if (ret) {return ret;}
     return msgpack_pack_timestamp(x, time);
 }
+
+#endif
 
 #undef msgpack_pack_inline_func
 #undef msgpack_pack_user

--- a/include/msgpack/pack_template.h
+++ b/include/msgpack/pack_template.h
@@ -890,6 +890,42 @@ msgpack_pack_inline_func(_ext_body)(msgpack_pack_user x, const void* b, size_t l
     msgpack_pack_append_buffer(x, (const unsigned char*)b, l);
 }
 
+/*
+ * Timestamp
+ */
+
+msgpack_pack_inline_func(_timestamp)(msgpack_pack_user x, struct timespec time)
+{
+    if ((time.tv_sec >> 34) == 0) {
+        uint64_t data64 = (time.tv_nsec << 34) | time.tv_sec;
+        if (data64 & 0xffffffff00000000L)   {
+            // timestamp 64
+            msgpack_pack_ext(x, 8, -1);
+            msgpack_pack_real_uint64(x, data64);
+        } else {
+            // timestamp 32
+            uint32_t data32 = data64;
+            msgpack_pack_ext(x, 4, -1);
+            msgpack_pack_real_uint32(x, data32);
+        }
+    } else  {
+        // timestamp 96
+        uint32_t ns = time.tv_nsec;
+        uint64_t s = time.tv_sec;
+        msgpack_pack_ext(x, 12, -1);
+        msgpack_pack_real_uint32(x, ns);
+        msgpack_pack_real_uint64(x, s);
+    }
+}
+
+msgpack_pack_inline_func(_timestamp_now)(msgpack_pack_user x)
+{
+    struct timespec time;
+    int ret = timespec_get(&time, TIME_UTC);
+    if (ret) {return ret;}
+    return msgpack_pack_timestamp(x, time);
+}
+
 #undef msgpack_pack_inline_func
 #undef msgpack_pack_user
 #undef msgpack_pack_append_buffer

--- a/src/objectc.c
+++ b/src/objectc.c
@@ -65,6 +65,11 @@ int msgpack_pack_object(msgpack_packer* pk, msgpack_object d)
             return msgpack_pack_bin_body(pk, d.via.bin.ptr, d.via.bin.size);
         }
 
+    case MSGPACK_OBJECT_TIMESTAMP:
+        {
+            return msgpack_pack_timestamp(pk, d.via.time.timespec);
+        }
+
     case MSGPACK_OBJECT_EXT:
         {
             int ret = msgpack_pack_ext(pk, d.via.ext.size, d.via.ext.type);

--- a/src/objectc.c
+++ b/src/objectc.c
@@ -65,10 +65,12 @@ int msgpack_pack_object(msgpack_packer* pk, msgpack_object d)
             return msgpack_pack_bin_body(pk, d.via.bin.ptr, d.via.bin.size);
         }
 
+#ifdef TIME_UTC
     case MSGPACK_OBJECT_TIMESTAMP:
         {
             return msgpack_pack_timestamp(pk, d.via.time.timespec);
         }
+#endif
 
     case MSGPACK_OBJECT_EXT:
         {


### PR DESCRIPTION
This does not add support for *unpacking* in C, but this gives a rough idea for how I was viewing support for packing.

`timespec_get()` should be a portable function. It's under the C11 standard, and has nanosecond resolution (though on some systems not nanosecond precision). `TIME_UTC` should be defined on all systems with `timespec_get()`

I added a check that only defines these functions if `TIME_UTC` is defined. That way we keep the same level of portability that it had previously, and developers can check for this feature by seeing if `TIME_UTC` is defined.

If you like this design, I will add unpacking support this weekend. Otherwise, I will try to address your critiques. I did not see how to run the tests at first glance, so this is not tested code. Please treat it more as a design idea in that regard.